### PR TITLE
Allow sausage recipes to use meat scraps

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -656,7 +656,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "char_smoker", 10 ] ] ],
     "components": [
-      [ [ "meat", 3 ], [ "rehydrated_meat", 6 ], [ "meat_canned", 6 ], [ "can_chicken", 6 ] ],
+      [ [ "meat", 3 ], [ "meat_scrap", 70 ], [ "rehydrated_meat", 6 ], [ "meat_canned", 6 ], [ "can_chicken", 6 ] ],
       [ [ "fat", 3 ], [ "tallow", 3 ], [ "lard", 3 ] ],
       [
         [ "salt", 10 ],
@@ -681,7 +681,7 @@
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "components": [
-      [ [ "meat", 2 ], [ "rehydrated_meat", 4 ], [ "meat_canned", 4 ], [ "can_chicken", 4 ] ],
+      [ [ "meat", 2 ], [ "meat_scrap", 45 ], [ "rehydrated_meat", 4 ], [ "meat_canned", 4 ], [ "can_chicken", 4 ] ],
       [ [ "fat", 1 ], [ "tallow", 1 ], [ "lard", 1 ] ],
       [
         [ "salt", 10 ],
@@ -705,7 +705,7 @@
     "batch_time_factors": [ 50, 3 ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "COOK", "level": 1 } ],
     "components": [
-      [ [ "meat", 3 ] ],
+      [ [ "meat", 3 ], [ "meat_scrap", 70 ], ],
       [ [ "fat", 3 ], [ "tallow", 3 ], [ "lard", 3 ] ],
       [
         [ "salt", 10 ],


### PR DESCRIPTION
<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text ( surrounded with <!-- and -​-> ) with text describing your PR.
-->

#### Summary
SUMMARY: Balance "Enable using meat scraps to make sausages"

#### Purpose of change
Simply allows crafting of sausages, raw sausages, and bratwurst with meat scraps instead of chunks of meat.

#### Describe the solution
Add component to the sausage recipes: "meat_scrap". Attempt to specify a proportional quantity of meat scraps to chunks of meat.

#### Describe alternatives you've considered
Becoming a vegan?

#### Additional context
This is my first PR!

